### PR TITLE
docs(plan): 標記 003 移植的 PR#13 後續修正已完成

### DIFF
--- a/specs/003-cloudinary-to-storage/plan.md
+++ b/specs/003-cloudinary-to-storage/plan.md
@@ -173,6 +173,15 @@ Admin SDK，一次性、可重跑、冪等：
 - **整合（emulator）**：上傳 → `photoUrl` 寫入 → 顯示；離職 → 檔案被刪；`storage.rules` 授權測試（本人可寫、admin 可寫／刪他人、非本人非 admin 被拒、超過 1MB 被拒、非圖片被拒、未登入不可讀）。
 - **搬遷腳本**：對 emulator 跑 dry-run 驗證篩選（含離職者跳過、冪等）。
 
+## PR#13 後續修正（已完成，PR#15 / 2026-06-18）
+
+回應 PR#13 程式碼審查遺留意見，已於 PR#15 補齊並合併（merge `dd27646`）：
+
+- **離職流程單元測試**（原審查 #4）：新增 `src/app/services/user.service.spec.ts`，覆蓋 `updateUserAdvanced` 三條商業規則——無 `exitDate` 不清頭像、有 `exitDate` 清 `photoUrl` 並刪檔、刪檔失敗仍不阻斷離職。補齊「測試是交付門檻」缺口。
+- **頭像上傳重構**（原審查 #1/#2）：`user-profile` 的 `onAvatarSelected` 巢狀 subscribe 改 `switchMap` + `takeUntilDestroyed`；`photoUrl` 表單值改於 Firestore 寫入成功後才更新（消除競態）；錯誤改固定友善訊息 + `console.error`，不洩漏內部資訊。
+- **spec.md 補齊**（原審查 #9）：見 [spec.md](./spec.md)。
+- **測試 seam 架構決策**：`UserService` 新增 `readonly _fn = { doc, updateDoc }`，並將 `list$` 查詢以 `defer()` 延後至訂閱時建立。`_fn` 為 public 屬性、供單元測試覆寫攔截 Firestore 模組函式（規避 ES module non-configurable），此取捨**刻意沿用 evaluation 服務既有慣例**，不改為 `protected` 以維持測試存取一致。
+
 ## 上線步驟（建議順序，可平滑回退）
 
 1. 加 `provideStorage` + `storage.rules` + emulator 設定，本地驗證新上傳流程（此時 Cloudinary 仍在）。


### PR DESCRIPTION
## 摘要

純文件變更。於 `specs/003-cloudinary-to-storage/plan.md` 新增「PR#13 後續修正（已完成，PR#15）」段落，將 PR#15（merge `dd27646`）的成果回填至計畫文件。

## 內容

- 記錄三項 PR#13 審查遺留意見的完成狀態：
  - #4 離職流程單元測試（`user.service.spec.ts`）
  - #1/#2 頭像上傳重構（`switchMap` + `takeUntilDestroyed`、修表單競態、錯誤訊息固定化）
  - #9 `spec.md` 補齊
- 入帳架構決策：`_fn` 測試 seam（沿用 evaluation 服務慣例，刻意維持 public 以利測試存取）與 `list$` 的 `defer()` 延後初始化。

## 影響範圍

僅 `plan.md` 一檔、+9 行，無程式碼或行為變更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)