### PR TITLE
fix: 回應 PR #19 最新 Claude 複審

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -94,6 +94,7 @@ service cloud.firestore {
       allow create: if isSignedIn() && validAttachmentCount(request.resource.data)
         && (!('attachments' in request.resource.data) || request.resource.data.attachments.size() == 0
           || request.resource.data.userId == request.auth.uid || isAdmin());
+      // 已知歷史行為：非附件欄位仍允許任意已登入使用者更新；全面收斂 attendance 權限須另案處理。
       allow update: if isSignedIn() && validAttachmentCount(request.resource.data)
         && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['attachments'])
           || isAdmin()

--- a/src/app/attachments/attachment-list.component.ts
+++ b/src/app/attachments/attachment-list.component.ts
@@ -5,6 +5,7 @@ import { MatIconModule } from '@angular/material/icon';
 
 import { AttachmentMetadata, MAX_ATTACHMENT_COUNT } from './attachment.models';
 import { ATTACHMENT_ERROR_MESSAGES, validateAttachmentSelection } from '../utils/attachment-validation';
+import { formatAttachmentSize } from '../utils/attachment-format';
 import { AttachmentPreviewDialogComponent } from './attachment-preview-dialog.component';
 
 @Component({
@@ -28,7 +29,7 @@ export class AttachmentListComponent {
   constructor(private readonly dialog: MatDialog) {}
 
   formatSize(bytes: number): string {
-    return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
+    return formatAttachmentSize(bytes);
   }
 
   async onSelected(event: Event): Promise<void> {

--- a/src/app/attachments/attachment-preview-dialog.component.html
+++ b/src/app/attachments/attachment-preview-dialog.component.html
@@ -1,4 +1,7 @@
-<h2 mat-dialog-title>{{ name }}</h2>
+<div class="dialog-title" mat-dialog-title>
+  <h2>{{ name }}</h2>
+  <button type="button" mat-button mat-dialog-close aria-label="關閉附件預覽">關閉</button>
+</div>
 <mat-dialog-content>
   @if (loading) { <mat-spinner diameter="36"></mat-spinner> }
   @if (error) {

--- a/src/app/attachments/attachment-preview-dialog.component.scss
+++ b/src/app/attachments/attachment-preview-dialog.component.scss
@@ -1,3 +1,5 @@
+.dialog-title { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.dialog-title h2 { margin: 0; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 mat-dialog-content { width: min(80vw, 720px); min-height: 240px; }
 img, object { display: block; width: 100%; max-height: 75vh; object-fit: contain; }
 object { height: 70vh; }

--- a/src/app/attachments/attachment-preview-dialog.component.ts
+++ b/src/app/attachments/attachment-preview-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { MAT_DIALOG_DATA, MatDialogContent, MatDialogTitle } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogClose, MatDialogContent, MatDialogTitle } from '@angular/material/dialog';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { firstValueFrom } from 'rxjs';
 
@@ -10,7 +11,7 @@ import { AttachmentService } from '../services/attachment.service';
 @Component({
   selector: 'app-attachment-preview-dialog',
   standalone: true,
-  imports: [MatDialogTitle, MatDialogContent, MatProgressSpinnerModule],
+  imports: [MatButtonModule, MatDialogClose, MatDialogTitle, MatDialogContent, MatProgressSpinnerModule],
   templateUrl: './attachment-preview-dialog.component.html',
   styleUrl: './attachment-preview-dialog.component.scss',
 })

--- a/src/app/attachments/attachment.models.ts
+++ b/src/app/attachments/attachment.models.ts
@@ -47,7 +47,7 @@ export interface AttachmentUploadContext {
 }
 
 export interface PreparedAttachmentBatch {
-  sessionId: string;
+  sessionId: string | null;
   attachments: AttachmentMetadata[];
 }
 

--- a/src/app/attendance/attendance-history/attendance-history.component.ts
+++ b/src/app/attendance/attendance-history/attendance-history.component.ts
@@ -13,6 +13,7 @@ import { Observable } from 'rxjs';
 import { AttendanceService } from '../../services/attendance.service';
 import { FirestoreTimestampPipe } from '../../pipes/firestore-timestamp.pipe';
 import { UserNamePipe } from '../../pipes/user-name.pipe';
+import { getAttachmentAuditContentLabel } from '../../utils/attachment-format';
 
 @Component({
   selector: 'app-attendance-history',
@@ -56,13 +57,6 @@ export class AttendanceHistoryComponent {
   }
 
   getContentLabel(content: string | undefined, action: string): string {
-    if (!content || !['新增附件', '刪除附件'].includes(action)) return content ?? '';
-    try {
-      const items = JSON.parse(content).attachments;
-      if (!Array.isArray(items)) return content;
-      return items.map((item) => `${item.originalName}（${this.formatSize(item.size)}）`).join('、');
-    } catch { return content; }
+    return getAttachmentAuditContentLabel(content, action);
   }
-
-  private formatSize(bytes: number): string { return `${(bytes / 1024 / 1024).toFixed(2)} MiB`; }
 }

--- a/src/app/attendance/attendance.component.ts
+++ b/src/app/attendance/attendance.component.ts
@@ -235,7 +235,7 @@ export class AttendanceComponent implements OnInit {
           error: (error) => {
             this.saving = false;
             this.dialogRef.disableClose = false;
-            this.saveError = error.message;
+            this.saveError = error instanceof Error ? error.message : '操作失敗，請重試。';
           },
         });
     } else {
@@ -258,7 +258,7 @@ export class AttendanceComponent implements OnInit {
           error: (error) => {
             this.saving = false;
             this.dialogRef.disableClose = false;
-            this.saveError = error.message;
+            this.saveError = error instanceof Error ? error.message : '操作失敗，請重試。';
           },
         });
     }

--- a/src/app/services/attachment.service.ts
+++ b/src/app/services/attachment.service.ts
@@ -105,7 +105,9 @@ export class AttachmentService {
       });
       if (prepared.attachments.length) {
         batch.set(doc(collection(requestRef, 'auditTrail')), this.audit('新增附件', options.actorUid, prepared.attachments));
-        batch.delete(doc(this.firestore, 'requestAttachmentUploadSessions', prepared.sessionId));
+        if (prepared.sessionId) {
+          batch.delete(doc(this.firestore, 'requestAttachmentUploadSessions', prepared.sessionId));
+        }
       }
       await batch.commit();
       return requestRef.id;
@@ -145,7 +147,9 @@ export class AttachmentService {
         }
         if (preparedBatch.attachments.length) {
           transaction.set(doc(collection(requestRef, 'auditTrail')), this.audit('新增附件', options.actorUid, preparedBatch.attachments));
-          transaction.delete(doc(this.firestore, 'requestAttachmentUploadSessions', preparedBatch.sessionId));
+          if (preparedBatch.sessionId) {
+            transaction.delete(doc(this.firestore, 'requestAttachmentUploadSessions', preparedBatch.sessionId));
+          }
         }
         if (removedItems.length) {
           transaction.set(doc(collection(requestRef, 'auditTrail')), this.audit('刪除附件', options.actorUid, removedItems));
@@ -178,7 +182,7 @@ export class AttachmentService {
     actorUid: string,
     files: readonly File[]
   ): Promise<PreparedAttachmentBatch> {
-    if (!files.length) return { sessionId: '', attachments: [] };
+    if (!files.length) return { sessionId: null, attachments: [] };
     if (files.length > MAX_ATTACHMENT_COUNT) throw new Error('too-many-files');
     for (const file of files) {
       const validationError = await validateAttachmentFile(file);

--- a/src/app/subsidy/subsidy-application/subsidy-application.component.ts
+++ b/src/app/subsidy/subsidy-application/subsidy-application.component.ts
@@ -274,7 +274,7 @@ export class SubsidyApplicationComponent implements OnInit {
             console.error('更新失敗：', error);
             this.saving = false;
             this.dialogRef.disableClose = false;
-            this.saveError = error.message;
+            this.saveError = error instanceof Error ? error.message : '操作失敗，請重試。';
           },
         });
     } else {
@@ -292,7 +292,7 @@ export class SubsidyApplicationComponent implements OnInit {
             console.error('建立失敗：', error);
             this.saving = false;
             this.dialogRef.disableClose = false;
-            this.saveError = error.message;
+            this.saveError = error instanceof Error ? error.message : '操作失敗，請重試。';
           },
         });
     }

--- a/src/app/subsidy/subsidy-history/subsidy-history.component.ts
+++ b/src/app/subsidy/subsidy-history/subsidy-history.component.ts
@@ -14,6 +14,7 @@ import { SubsidyAuditTrail, SubsidyService } from '../../services/subsidy.servic
 import { FirestoreTimestampPipe } from '../../pipes/firestore-timestamp.pipe';
 import { UserNamePipe } from '../../pipes/user-name.pipe';
 import { SubsidyStatusPipe } from '../../pipes/subsidy-status.pipe';
+import { getAttachmentAuditContentLabel } from '../../utils/attachment-format';
 
 @Component({
   selector: 'app-subsidy-history',
@@ -64,11 +65,6 @@ export class SubsidyHistoryComponent {
   }
 
   getContentLabel(content: string | undefined, action: string): string {
-    if (!content || !['新增附件', '刪除附件'].includes(action)) return content ?? '';
-    try {
-      const items = JSON.parse(content).attachments;
-      if (!Array.isArray(items)) return content;
-      return items.map((item) => `${item.originalName}（${(item.size / 1024 / 1024).toFixed(2)} MiB）`).join('、');
-    } catch { return content; }
+    return getAttachmentAuditContentLabel(content, action);
   }
 }

--- a/src/app/utils/attachment-format.spec.ts
+++ b/src/app/utils/attachment-format.spec.ts
@@ -1,0 +1,20 @@
+import { formatAttachmentSize, getAttachmentAuditContentLabel } from './attachment-format';
+
+describe('attachment formatting', () => {
+  it('formats bytes as MiB with two decimal places', () => {
+    expect(formatAttachmentSize(1572864)).toBe('1.50 MiB');
+  });
+
+  it('formats structured attachment audit content', () => {
+    const content = JSON.stringify({
+      attachments: [{ originalName: '證明.pdf', size: 1048576 }],
+    });
+
+    expect(getAttachmentAuditContentLabel(content, '新增附件')).toBe('證明.pdf（1.00 MiB）');
+  });
+
+  it('preserves legacy or malformed audit content', () => {
+    expect(getAttachmentAuditContentLabel('legacy', '更新')).toBe('legacy');
+    expect(getAttachmentAuditContentLabel('{invalid', '刪除附件')).toBe('{invalid');
+  });
+});

--- a/src/app/utils/attachment-format.ts
+++ b/src/app/utils/attachment-format.ts
@@ -1,0 +1,19 @@
+const ATTACHMENT_AUDIT_ACTIONS = ['新增附件', '刪除附件'];
+
+export function formatAttachmentSize(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
+}
+
+export function getAttachmentAuditContentLabel(content: string | undefined, action: string): string {
+  if (!content || !ATTACHMENT_AUDIT_ACTIONS.includes(action)) return content ?? '';
+
+  try {
+    const items = JSON.parse(content).attachments;
+    if (!Array.isArray(items)) return content;
+    return items
+      .map((item) => `${item.originalName}（${formatAttachmentSize(item.size)}）`)
+      .join('、');
+  } catch {
+    return content;
+  }
+}


### PR DESCRIPTION
## 背景

本 PR 接續已合併的 PR #19，檢查 2026-06-20 16:47 UTC 最新一輪 Claude Bot 複審，並在不改變 005-request-attachments 產品規格與安全模型的前提下處理仍有效的建議。

本輪重新核對憲章、005 spec／plan、Rules 契約與現行實作後，未發現需要產品決策的憲章或規格衝突，因此未進入提問模式。

## 本次調整

- 新增共用 attachment-format utility，統一附件 MiB 大小與結構化 audit 內容顯示，Attendance、Subsidy 歷程及附件清單不再各自維護重複邏輯。
- 將無附件批次的 upload session ID 由空字串改為 null，讓「未建立 session」成為明確型別狀態，並在提交／回滾處保留安全 guard。
- 在附件預覽 dialog 標題列加入具 aria-label 的明確關閉按鈕，改善行動裝置、鍵盤與輔助技術操作。
- Attendance 與 Subsidy 儲存錯誤對非 Error 值加入固定繁中 fallback，避免 UI 顯示 undefined。
- 在 attendanceLogs 更新規則旁註明：非附件欄位對 authenticated 使用者開放屬已知歷史行為，全面權限收斂應另案處理。

## 複審判定

- Storage create rule 已同時驗證 metadata.requestKind、requestId、attachmentId、uploadedBy，並由 hasValidUploadSession 驗證 ownerUid 與 session，因此最新留言中的 metadata 一致性疑慮已由現行 Rules 涵蓋，未重複修改。
- request attachment 的兩份 xdescribe spec 頂端已明記由 tools/request-attachment-emulator-tests.cjs／npm run test:attachment-rules 執行，建議內容已存在。
- Emulator runner 拆分為測試框架屬非阻斷維護重構；本輪維持已可執行且通過的矩陣，避免為複審建議擴張功能修正範圍。

## 驗證

- npm test -- --watch=false：225 SUCCESS、68 skipped。
- app/spec TypeScript noEmit：通過。
- Firestore／Storage Emulator Rules matrix：PASS。
- attachment orphan audit：PASS。
- git diff --check：PASS。
- npm run build：現有 node_modules 僅含 darwin-arm64 esbuild，但目前 Node 為 darwin-x64，bundling 啟動前即因本機依賴架構不符中止；沒有出現本次程式碼的編譯錯誤。

## 變更範圍

本 PR 未包含工作目錄中既有的 .gitignore、AGENTS.md 與 .codex/ 變更。合併時請依儲存庫偏好使用 merge commit，不使用 squash merge。