### PR TITLE
fix: 強化附件複審修正與稽核格式邊界

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -94,6 +94,7 @@ service cloud.firestore {
       allow create: if isSignedIn() && validAttachmentCount(request.resource.data)
         && (!('attachments' in request.resource.data) || request.resource.data.attachments.size() == 0
           || request.resource.data.userId == request.auth.uid || isAdmin());
+      // 已知歷史行為：非附件欄位仍允許任意已登入使用者更新；全面收斂 attendance 權限須另案處理。
       allow update: if isSignedIn() && validAttachmentCount(request.resource.data)
         && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['attachments'])
           || isAdmin()

--- a/firestore.rules
+++ b/firestore.rules
@@ -94,7 +94,7 @@ service cloud.firestore {
       allow create: if isSignedIn() && validAttachmentCount(request.resource.data)
         && (!('attachments' in request.resource.data) || request.resource.data.attachments.size() == 0
           || request.resource.data.userId == request.auth.uid || isAdmin());
-      // 已知歷史行為：非附件欄位仍允許任意已登入使用者更新；全面收斂 attendance 權限須另案處理。
+      // 已知歷史行為：非附件欄位仍允許任意已登入使用者更新；權限收斂追蹤：GitHub issue #22。
       allow update: if isSignedIn() && validAttachmentCount(request.resource.data)
         && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['attachments'])
           || isAdmin()

--- a/src/app/attachments/attachment-list.component.ts
+++ b/src/app/attachments/attachment-list.component.ts
@@ -28,9 +28,7 @@ export class AttachmentListComponent {
 
   constructor(private readonly dialog: MatDialog) {}
 
-  formatSize(bytes: number): string {
-    return formatAttachmentSize(bytes);
-  }
+  readonly formatSize = formatAttachmentSize;
 
   async onSelected(event: Event): Promise<void> {
     const input = event.target as HTMLInputElement;

--- a/src/app/attachments/attachment-list.component.ts
+++ b/src/app/attachments/attachment-list.component.ts
@@ -5,6 +5,7 @@ import { MatIconModule } from '@angular/material/icon';
 
 import { AttachmentMetadata, MAX_ATTACHMENT_COUNT } from './attachment.models';
 import { ATTACHMENT_ERROR_MESSAGES, validateAttachmentSelection } from '../utils/attachment-validation';
+import { formatAttachmentSize } from '../utils/attachment-format';
 import { AttachmentPreviewDialogComponent } from './attachment-preview-dialog.component';
 
 @Component({
@@ -28,7 +29,7 @@ export class AttachmentListComponent {
   constructor(private readonly dialog: MatDialog) {}
 
   formatSize(bytes: number): string {
-    return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
+    return formatAttachmentSize(bytes);
   }
 
   async onSelected(event: Event): Promise<void> {

--- a/src/app/attachments/attachment-preview-dialog.component.html
+++ b/src/app/attachments/attachment-preview-dialog.component.html
@@ -1,4 +1,7 @@
-<h2 mat-dialog-title>{{ name }}</h2>
+<div class="dialog-title" mat-dialog-title>
+  <h2>{{ name }}</h2>
+  <button type="button" mat-button mat-dialog-close aria-label="關閉附件預覽">關閉</button>
+</div>
 <mat-dialog-content>
   @if (loading) { <mat-spinner diameter="36"></mat-spinner> }
   @if (error) {

--- a/src/app/attachments/attachment-preview-dialog.component.scss
+++ b/src/app/attachments/attachment-preview-dialog.component.scss
@@ -1,5 +1,18 @@
-.dialog-title { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
-.dialog-title h2 { margin: 0; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dialog-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.dialog-title h2 {
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 mat-dialog-content { width: min(80vw, 720px); min-height: 240px; }
 img, object { display: block; width: 100%; max-height: 75vh; object-fit: contain; }
 object { height: 70vh; }

--- a/src/app/attachments/attachment-preview-dialog.component.scss
+++ b/src/app/attachments/attachment-preview-dialog.component.scss
@@ -13,8 +13,33 @@
   white-space: nowrap;
 }
 
-mat-dialog-content { width: min(80vw, 720px); min-height: 240px; }
-img, object { display: block; width: 100%; max-height: 75vh; object-fit: contain; }
-object { height: 70vh; }
-.error { color: #b3261e; }
-@media (max-width: 600px) { mat-dialog-content { width: 100%; } object { height: 60vh; } }
+mat-dialog-content {
+  width: min(80vw, 720px);
+  min-height: 240px;
+}
+
+img,
+object {
+  display: block;
+  width: 100%;
+  max-height: 75vh;
+  object-fit: contain;
+}
+
+object {
+  height: 70vh;
+}
+
+.error {
+  color: #b3261e;
+}
+
+@media (max-width: 600px) {
+  mat-dialog-content {
+    width: 100%;
+  }
+
+  object {
+    height: 60vh;
+  }
+}

--- a/src/app/attachments/attachment-preview-dialog.component.scss
+++ b/src/app/attachments/attachment-preview-dialog.component.scss
@@ -1,3 +1,5 @@
+.dialog-title { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.dialog-title h2 { margin: 0; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 mat-dialog-content { width: min(80vw, 720px); min-height: 240px; }
 img, object { display: block; width: 100%; max-height: 75vh; object-fit: contain; }
 object { height: 70vh; }

--- a/src/app/attachments/attachment-preview-dialog.component.ts
+++ b/src/app/attachments/attachment-preview-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { MAT_DIALOG_DATA, MatDialogContent, MatDialogTitle } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogClose, MatDialogContent, MatDialogTitle } from '@angular/material/dialog';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { firstValueFrom } from 'rxjs';
 
@@ -10,7 +11,7 @@ import { AttachmentService } from '../services/attachment.service';
 @Component({
   selector: 'app-attachment-preview-dialog',
   standalone: true,
-  imports: [MatDialogTitle, MatDialogContent, MatProgressSpinnerModule],
+  imports: [MatButtonModule, MatDialogClose, MatDialogTitle, MatDialogContent, MatProgressSpinnerModule],
   templateUrl: './attachment-preview-dialog.component.html',
   styleUrl: './attachment-preview-dialog.component.scss',
 })

--- a/src/app/attachments/attachment.models.ts
+++ b/src/app/attachments/attachment.models.ts
@@ -47,7 +47,7 @@ export interface AttachmentUploadContext {
 }
 
 export interface PreparedAttachmentBatch {
-  sessionId: string;
+  sessionId: string | null;
   attachments: AttachmentMetadata[];
 }
 

--- a/src/app/attachments/attachment.models.ts
+++ b/src/app/attachments/attachment.models.ts
@@ -46,6 +46,9 @@ export interface AttachmentUploadContext {
   ownerUid: string;
 }
 
+/**
+ * 空批次以 sessionId: null 表示未建立遠端工作階段；有附件時 sessionId 必為非空字串。
+ */
 export interface PreparedAttachmentBatch {
   sessionId: string | null;
   attachments: AttachmentMetadata[];

--- a/src/app/attendance/attendance-history/attendance-history.component.ts
+++ b/src/app/attendance/attendance-history/attendance-history.component.ts
@@ -13,6 +13,7 @@ import { Observable } from 'rxjs';
 import { AttendanceService } from '../../services/attendance.service';
 import { FirestoreTimestampPipe } from '../../pipes/firestore-timestamp.pipe';
 import { UserNamePipe } from '../../pipes/user-name.pipe';
+import { getAttachmentAuditContentLabel } from '../../utils/attachment-format';
 
 @Component({
   selector: 'app-attendance-history',
@@ -56,13 +57,6 @@ export class AttendanceHistoryComponent {
   }
 
   getContentLabel(content: string | undefined, action: string): string {
-    if (!content || !['新增附件', '刪除附件'].includes(action)) return content ?? '';
-    try {
-      const items = JSON.parse(content).attachments;
-      if (!Array.isArray(items)) return content;
-      return items.map((item) => `${item.originalName}（${this.formatSize(item.size)}）`).join('、');
-    } catch { return content; }
+    return getAttachmentAuditContentLabel(content, action);
   }
-
-  private formatSize(bytes: number): string { return `${(bytes / 1024 / 1024).toFixed(2)} MiB`; }
 }

--- a/src/app/attendance/attendance.component.spec.ts
+++ b/src/app/attendance/attendance.component.spec.ts
@@ -123,4 +123,20 @@ describe('AttendanceComponent attachments', () => {
     expect(dialogRef.disableClose).toBeFalse();
     expect(component.saveError).toBe('儲存失敗');
   });
+
+  it('shows a safe fallback when create rejects with a non-Error value', () => {
+    const service = {
+      typeList: [], reasonPriorityList: [],
+      create: jasmine.createSpy().and.returnValue(throwError(() => 'firebase-rejected')),
+    };
+    const component = create(undefined, service);
+    component.currentUser = { uid: 'owner' } as any;
+    component.attendanceForm.patchValue({
+      type: 1, reason: 'reason', userId: 'owner', startDateTime: new Date() as any, endDateTime: new Date() as any,
+    });
+
+    component.save();
+
+    expect(component.saveError).toBe('操作失敗，請重試。');
+  });
 });

--- a/src/app/attendance/attendance.component.spec.ts
+++ b/src/app/attendance/attendance.component.spec.ts
@@ -139,4 +139,25 @@ describe('AttendanceComponent attachments', () => {
 
     expect(component.saveError).toBe('操作失敗，請重試。');
   });
+
+  it('shows a safe fallback when update rejects with a non-Error value', () => {
+    const service = {
+      typeList: [], reasonPriorityList: [],
+      update: jasmine.createSpy().and.returnValue(throwError(() => ({ code: 'firebase-rejected' }))),
+    };
+    const attendance = {
+      id: 'request-1', userId: 'owner', status: 'pending', attachments: [],
+      type: 1, reason: 'reason', startDateTime: new Date(), endDateTime: new Date(),
+    };
+    const component = create(attendance, service);
+    component.currentUser = { uid: 'owner' } as any;
+    component.attendanceForm.patchValue({
+      type: 1, reason: 'reason', userId: 'owner', startDateTime: new Date() as any, endDateTime: new Date() as any,
+    });
+
+    component.save();
+
+    expect(service.update).toHaveBeenCalled();
+    expect(component.saveError).toBe('操作失敗，請重試。');
+  });
 });

--- a/src/app/attendance/attendance.component.ts
+++ b/src/app/attendance/attendance.component.ts
@@ -235,7 +235,7 @@ export class AttendanceComponent implements OnInit {
           error: (error) => {
             this.saving = false;
             this.dialogRef.disableClose = false;
-            this.saveError = error.message;
+            this.saveError = error instanceof Error ? error.message : '操作失敗，請重試。';
           },
         });
     } else {
@@ -258,7 +258,7 @@ export class AttendanceComponent implements OnInit {
           error: (error) => {
             this.saving = false;
             this.dialogRef.disableClose = false;
-            this.saveError = error.message;
+            this.saveError = error instanceof Error ? error.message : '操作失敗，請重試。';
           },
         });
     }

--- a/src/app/services/attachment.service.ts
+++ b/src/app/services/attachment.service.ts
@@ -105,7 +105,6 @@ export class AttachmentService {
       });
       if (prepared.attachments.length) {
         batch.set(doc(collection(requestRef, 'auditTrail')), this.audit('新增附件', options.actorUid, prepared.attachments));
-        // prepareUploads 保證有附件時必定建立 session；guard 保留 nullable batch 型別的防禦邊界。
         if (prepared.sessionId) {
           batch.delete(doc(this.firestore, 'requestAttachmentUploadSessions', prepared.sessionId));
         }
@@ -148,7 +147,6 @@ export class AttachmentService {
         }
         if (preparedBatch.attachments.length) {
           transaction.set(doc(collection(requestRef, 'auditTrail')), this.audit('新增附件', options.actorUid, preparedBatch.attachments));
-          // prepareUploads 保證有附件時必定建立 session；guard 保留 nullable batch 型別的防禦邊界。
           if (preparedBatch.sessionId) {
             transaction.delete(doc(this.firestore, 'requestAttachmentUploadSessions', preparedBatch.sessionId));
           }

--- a/src/app/services/attachment.service.ts
+++ b/src/app/services/attachment.service.ts
@@ -105,6 +105,7 @@ export class AttachmentService {
       });
       if (prepared.attachments.length) {
         batch.set(doc(collection(requestRef, 'auditTrail')), this.audit('新增附件', options.actorUid, prepared.attachments));
+        // prepareUploads 保證有附件時必定建立 session；guard 保留 nullable batch 型別的防禦邊界。
         if (prepared.sessionId) {
           batch.delete(doc(this.firestore, 'requestAttachmentUploadSessions', prepared.sessionId));
         }
@@ -147,6 +148,7 @@ export class AttachmentService {
         }
         if (preparedBatch.attachments.length) {
           transaction.set(doc(collection(requestRef, 'auditTrail')), this.audit('新增附件', options.actorUid, preparedBatch.attachments));
+          // prepareUploads 保證有附件時必定建立 session；guard 保留 nullable batch 型別的防禦邊界。
           if (preparedBatch.sessionId) {
             transaction.delete(doc(this.firestore, 'requestAttachmentUploadSessions', preparedBatch.sessionId));
           }

--- a/src/app/services/attachment.service.ts
+++ b/src/app/services/attachment.service.ts
@@ -105,7 +105,9 @@ export class AttachmentService {
       });
       if (prepared.attachments.length) {
         batch.set(doc(collection(requestRef, 'auditTrail')), this.audit('新增附件', options.actorUid, prepared.attachments));
-        batch.delete(doc(this.firestore, 'requestAttachmentUploadSessions', prepared.sessionId));
+        if (prepared.sessionId) {
+          batch.delete(doc(this.firestore, 'requestAttachmentUploadSessions', prepared.sessionId));
+        }
       }
       await batch.commit();
       return requestRef.id;
@@ -145,7 +147,9 @@ export class AttachmentService {
         }
         if (preparedBatch.attachments.length) {
           transaction.set(doc(collection(requestRef, 'auditTrail')), this.audit('新增附件', options.actorUid, preparedBatch.attachments));
-          transaction.delete(doc(this.firestore, 'requestAttachmentUploadSessions', preparedBatch.sessionId));
+          if (preparedBatch.sessionId) {
+            transaction.delete(doc(this.firestore, 'requestAttachmentUploadSessions', preparedBatch.sessionId));
+          }
         }
         if (removedItems.length) {
           transaction.set(doc(collection(requestRef, 'auditTrail')), this.audit('刪除附件', options.actorUid, removedItems));
@@ -178,7 +182,7 @@ export class AttachmentService {
     actorUid: string,
     files: readonly File[]
   ): Promise<PreparedAttachmentBatch> {
-    if (!files.length) return { sessionId: '', attachments: [] };
+    if (!files.length) return { sessionId: null, attachments: [] };
     if (files.length > MAX_ATTACHMENT_COUNT) throw new Error('too-many-files');
     for (const file of files) {
       const validationError = await validateAttachmentFile(file);

--- a/src/app/subsidy/subsidy-application/subsidy-application.component.spec.ts
+++ b/src/app/subsidy/subsidy-application/subsidy-application.component.spec.ts
@@ -77,6 +77,25 @@ describe('SubsidyApplicationComponent attachments', () => {
     expect(component.saveError).toBe('建立失敗');
   });
 
+  it('shows a safe fallback when create rejects with a non-Error value', () => {
+    const service = {
+      typeList: [],
+      create: jasmine.createSpy().and.returnValue(throwError(() => 'firebase-rejected')),
+    };
+    const component = new SubsidyApplicationComponent(
+      { close: jasmine.createSpy(), disableClose: false } as any,
+      service as any,
+      { list$: of([]), currentUser$: of(null) } as any,
+      { title: 'new' }
+    );
+    component.currentUser = { uid: 'owner', role: 'user' } as any;
+    component.subsidyForm.patchValue({ type: 1, userId: 'owner', applicationDate: new Date() });
+
+    component.onSubmit();
+
+    expect(component.saveError).toBe('操作失敗，請重試。');
+  });
+
   it('shows a clear error when authentication expires before submit', () => {
     const service = { typeList: [], create: jasmine.createSpy() };
     const component = new SubsidyApplicationComponent(

--- a/src/app/subsidy/subsidy-application/subsidy-application.component.spec.ts
+++ b/src/app/subsidy/subsidy-application/subsidy-application.component.spec.ts
@@ -1,4 +1,5 @@
 import { of, Subject, throwError } from 'rxjs';
+import { Timestamp } from '@angular/fire/firestore';
 import { SubsidyApplicationComponent } from './subsidy-application.component';
 
 describe('SubsidyApplicationComponent attachments', () => {
@@ -93,6 +94,30 @@ describe('SubsidyApplicationComponent attachments', () => {
 
     component.onSubmit();
 
+    expect(component.saveError).toBe('操作失敗，請重試。');
+  });
+
+  it('shows a safe fallback when update rejects with a non-Error value', () => {
+    const service = {
+      typeList: [],
+      update: jasmine.createSpy().and.returnValue(throwError(() => ({ code: 'firebase-rejected' }))),
+    };
+    const application = {
+      id: 'application-1', userId: 'owner', status: 'pending' as const, attachments: [],
+      type: 1, applicationDate: Timestamp.now(), createdAt: Timestamp.now(), updatedAt: Timestamp.now(),
+    };
+    const component = new SubsidyApplicationComponent(
+      { close: jasmine.createSpy(), disableClose: false } as any,
+      service as any,
+      { list$: of([]), currentUser$: of(null) } as any,
+      { title: 'edit', application }
+    );
+    component.currentUser = { uid: 'owner', role: 'user' } as any;
+    component.subsidyForm.patchValue({ type: 1, userId: 'owner', applicationDate: new Date() });
+
+    component.onSubmit();
+
+    expect(service.update).toHaveBeenCalled();
     expect(component.saveError).toBe('操作失敗，請重試。');
   });
 

--- a/src/app/subsidy/subsidy-application/subsidy-application.component.ts
+++ b/src/app/subsidy/subsidy-application/subsidy-application.component.ts
@@ -274,7 +274,7 @@ export class SubsidyApplicationComponent implements OnInit {
             console.error('更新失敗：', error);
             this.saving = false;
             this.dialogRef.disableClose = false;
-            this.saveError = error.message;
+            this.saveError = error instanceof Error ? error.message : '操作失敗，請重試。';
           },
         });
     } else {
@@ -292,7 +292,7 @@ export class SubsidyApplicationComponent implements OnInit {
             console.error('建立失敗：', error);
             this.saving = false;
             this.dialogRef.disableClose = false;
-            this.saveError = error.message;
+            this.saveError = error instanceof Error ? error.message : '操作失敗，請重試。';
           },
         });
     }

--- a/src/app/subsidy/subsidy-history/subsidy-history.component.ts
+++ b/src/app/subsidy/subsidy-history/subsidy-history.component.ts
@@ -14,6 +14,7 @@ import { SubsidyAuditTrail, SubsidyService } from '../../services/subsidy.servic
 import { FirestoreTimestampPipe } from '../../pipes/firestore-timestamp.pipe';
 import { UserNamePipe } from '../../pipes/user-name.pipe';
 import { SubsidyStatusPipe } from '../../pipes/subsidy-status.pipe';
+import { getAttachmentAuditContentLabel } from '../../utils/attachment-format';
 
 @Component({
   selector: 'app-subsidy-history',
@@ -64,11 +65,6 @@ export class SubsidyHistoryComponent {
   }
 
   getContentLabel(content: string | undefined, action: string): string {
-    if (!content || !['新增附件', '刪除附件'].includes(action)) return content ?? '';
-    try {
-      const items = JSON.parse(content).attachments;
-      if (!Array.isArray(items)) return content;
-      return items.map((item) => `${item.originalName}（${(item.size / 1024 / 1024).toFixed(2)} MiB）`).join('、');
-    } catch { return content; }
+    return getAttachmentAuditContentLabel(content, action);
   }
 }

--- a/src/app/utils/attachment-format.spec.ts
+++ b/src/app/utils/attachment-format.spec.ts
@@ -18,9 +18,13 @@ describe('attachment formatting', () => {
     expect(getAttachmentAuditContentLabel('{invalid', '刪除附件')).toBe('{invalid');
   });
 
-  it('returns an empty string for missing content or an empty attachment list', () => {
+  it('returns an empty string for missing content', () => {
     expect(getAttachmentAuditContentLabel(undefined, '新增附件')).toBe('');
-    expect(getAttachmentAuditContentLabel('{"attachments":[]}', '新增附件')).toBe('');
+  });
+
+  it('preserves raw audit content for an empty attachment list', () => {
+    const content = '{"attachments":[]}';
+    expect(getAttachmentAuditContentLabel(content, '新增附件')).toBe(content);
   });
 
   it('omits malformed attachment items without rendering undefined or NaN', () => {

--- a/src/app/utils/attachment-format.spec.ts
+++ b/src/app/utils/attachment-format.spec.ts
@@ -33,4 +33,10 @@ describe('attachment formatting', () => {
     expect(result).not.toContain('undefined');
     expect(result).not.toContain('NaN');
   });
+
+  it('preserves JSON whose root is null, an array, or another non-object value', () => {
+    expect(getAttachmentAuditContentLabel('null', '新增附件')).toBe('null');
+    expect(getAttachmentAuditContentLabel('[]', '新增附件')).toBe('[]');
+    expect(getAttachmentAuditContentLabel('"legacy"', '新增附件')).toBe('"legacy"');
+  });
 });

--- a/src/app/utils/attachment-format.spec.ts
+++ b/src/app/utils/attachment-format.spec.ts
@@ -39,4 +39,12 @@ describe('attachment formatting', () => {
     expect(getAttachmentAuditContentLabel('[]', '新增附件')).toBe('[]');
     expect(getAttachmentAuditContentLabel('"legacy"', '新增附件')).toBe('"legacy"');
   });
+
+  it('preserves the raw audit content when every attachment item is malformed', () => {
+    const content = JSON.stringify({
+      attachments: [null, {}, { originalName: '缺少大小.pdf' }],
+    });
+
+    expect(getAttachmentAuditContentLabel(content, '刪除附件')).toBe(content);
+  });
 });

--- a/src/app/utils/attachment-format.spec.ts
+++ b/src/app/utils/attachment-format.spec.ts
@@ -17,4 +17,20 @@ describe('attachment formatting', () => {
     expect(getAttachmentAuditContentLabel('legacy', '更新')).toBe('legacy');
     expect(getAttachmentAuditContentLabel('{invalid', '刪除附件')).toBe('{invalid');
   });
+
+  it('returns an empty string for missing content or an empty attachment list', () => {
+    expect(getAttachmentAuditContentLabel(undefined, '新增附件')).toBe('');
+    expect(getAttachmentAuditContentLabel('{"attachments":[]}', '新增附件')).toBe('');
+  });
+
+  it('omits malformed attachment items without rendering undefined or NaN', () => {
+    const content = JSON.stringify({
+      attachments: [null, {}, { originalName: '缺少大小.pdf' }, { originalName: '合法.pdf', size: 524288 }],
+    });
+
+    const result = getAttachmentAuditContentLabel(content, '刪除附件');
+    expect(result).toBe('合法.pdf（0.50 MiB）');
+    expect(result).not.toContain('undefined');
+    expect(result).not.toContain('NaN');
+  });
 });

--- a/src/app/utils/attachment-format.spec.ts
+++ b/src/app/utils/attachment-format.spec.ts
@@ -1,0 +1,20 @@
+import { formatAttachmentSize, getAttachmentAuditContentLabel } from './attachment-format';
+
+describe('attachment formatting', () => {
+  it('formats bytes as MiB with two decimal places', () => {
+    expect(formatAttachmentSize(1572864)).toBe('1.50 MiB');
+  });
+
+  it('formats structured attachment audit content', () => {
+    const content = JSON.stringify({
+      attachments: [{ originalName: '證明.pdf', size: 1048576 }],
+    });
+
+    expect(getAttachmentAuditContentLabel(content, '新增附件')).toBe('證明.pdf（1.00 MiB）');
+  });
+
+  it('preserves legacy or malformed audit content', () => {
+    expect(getAttachmentAuditContentLabel('legacy', '更新')).toBe('legacy');
+    expect(getAttachmentAuditContentLabel('{invalid', '刪除附件')).toBe('{invalid');
+  });
+});

--- a/src/app/utils/attachment-format.ts
+++ b/src/app/utils/attachment-format.ts
@@ -1,0 +1,19 @@
+const ATTACHMENT_AUDIT_ACTIONS = ['新增附件', '刪除附件'];
+
+export function formatAttachmentSize(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
+}
+
+export function getAttachmentAuditContentLabel(content: string | undefined, action: string): string {
+  if (!content || !ATTACHMENT_AUDIT_ACTIONS.includes(action)) return content ?? '';
+
+  try {
+    const items = JSON.parse(content).attachments;
+    if (!Array.isArray(items)) return content;
+    return items
+      .map((item) => `${item.originalName}（${formatAttachmentSize(item.size)}）`)
+      .join('、');
+  } catch {
+    return content;
+  }
+}

--- a/src/app/utils/attachment-format.ts
+++ b/src/app/utils/attachment-format.ts
@@ -12,15 +12,15 @@ export function getAttachmentAuditContentLabel(content: string | undefined, acti
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return content;
     const items: unknown = (parsed as Record<string, unknown>)['attachments'];
     if (!Array.isArray(items)) return content;
-    return items
+    const labels = items
       .map((item: unknown) => {
         if (typeof item !== 'object' || item === null) return '';
         const { originalName, size } = item as Record<string, unknown>;
         if (typeof originalName !== 'string' || typeof size !== 'number' || !Number.isFinite(size)) return '';
         return `${originalName}（${formatAttachmentSize(size)}）`;
       })
-      .filter(Boolean)
-      .join('、');
+      .filter(Boolean);
+    return labels.length > 0 || items.length === 0 ? labels.join('、') : content;
   } catch {
     return content;
   }

--- a/src/app/utils/attachment-format.ts
+++ b/src/app/utils/attachment-format.ts
@@ -8,7 +8,9 @@ export function getAttachmentAuditContentLabel(content: string | undefined, acti
   if (!content || !ATTACHMENT_AUDIT_ACTIONS.includes(action)) return content ?? '';
 
   try {
-    const items: unknown = JSON.parse(content).attachments;
+    const parsed: unknown = JSON.parse(content);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return content;
+    const items: unknown = (parsed as Record<string, unknown>)['attachments'];
     if (!Array.isArray(items)) return content;
     return items
       .map((item: unknown) => {

--- a/src/app/utils/attachment-format.ts
+++ b/src/app/utils/attachment-format.ts
@@ -8,10 +8,16 @@ export function getAttachmentAuditContentLabel(content: string | undefined, acti
   if (!content || !ATTACHMENT_AUDIT_ACTIONS.includes(action)) return content ?? '';
 
   try {
-    const items = JSON.parse(content).attachments;
+    const items: unknown = JSON.parse(content).attachments;
     if (!Array.isArray(items)) return content;
     return items
-      .map((item) => `${item.originalName}（${formatAttachmentSize(item.size)}）`)
+      .map((item: unknown) => {
+        if (typeof item !== 'object' || item === null) return '';
+        const { originalName, size } = item as Record<string, unknown>;
+        if (typeof originalName !== 'string' || typeof size !== 'number' || !Number.isFinite(size)) return '';
+        return `${originalName}（${formatAttachmentSize(size)}）`;
+      })
+      .filter(Boolean)
       .join('、');
   } catch {
     return content;

--- a/src/app/utils/attachment-format.ts
+++ b/src/app/utils/attachment-format.ts
@@ -1,5 +1,16 @@
 const ATTACHMENT_AUDIT_ACTIONS = ['新增附件', '刪除附件'];
 
+interface AuditAttachmentItem {
+  originalName: string;
+  size: number;
+}
+
+function isAuditAttachmentItem(item: unknown): item is AuditAttachmentItem {
+  if (typeof item !== 'object' || item === null) return false;
+  const { originalName, size } = item as Record<string, unknown>;
+  return typeof originalName === 'string' && typeof size === 'number' && Number.isFinite(size);
+}
+
 export function formatAttachmentSize(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
 }
@@ -13,16 +24,10 @@ export function getAttachmentAuditContentLabel(content: string | undefined, acti
     const items: unknown = (parsed as Record<string, unknown>)['attachments'];
     if (!Array.isArray(items)) return content;
     const labels = items
-      .map((item: unknown) => {
-        if (typeof item !== 'object' || item === null) return '';
-        const { originalName, size } = item as Record<string, unknown>;
-        if (typeof originalName !== 'string' || typeof size !== 'number' || !Number.isFinite(size)) return '';
-        return `${originalName}（${formatAttachmentSize(size)}）`;
-      })
-      .filter(Boolean);
-    // 非空陣列若沒有任何合法標籤，保留原始 JSON，避免損壞的 audit trail 在畫面上靜默消失。
-    const allItemsMalformed = labels.length === 0 && items.length > 0;
-    return allItemsMalformed ? content : labels.join('、');
+      .filter(isAuditAttachmentItem)
+      .map(({ originalName, size }) => `${originalName}（${formatAttachmentSize(size)}）`);
+    // 沒有可顯示項目時保留原始 JSON，避免空陣列或損壞內容在 audit trail 中靜默消失。
+    return labels.length === 0 ? content : labels.join('、');
   } catch {
     return content;
   }

--- a/src/app/utils/attachment-format.ts
+++ b/src/app/utils/attachment-format.ts
@@ -20,7 +20,9 @@ export function getAttachmentAuditContentLabel(content: string | undefined, acti
         return `${originalName}（${formatAttachmentSize(size)}）`;
       })
       .filter(Boolean);
-    return labels.length > 0 || items.length === 0 ? labels.join('、') : content;
+    // 非空陣列若沒有任何合法標籤，保留原始 JSON，避免損壞的 audit trail 在畫面上靜默消失。
+    const allItemsMalformed = labels.length === 0 && items.length > 0;
+    return allItemsMalformed ? content : labels.join('、');
   } catch {
     return content;
   }


### PR DESCRIPTION
## 背景

本 PR 取代 PR #20，並將原本過度簡略的 006 分支重新命名為 006-attachment-review-followup，使名稱與 005-request-attachments、004-training-ai-shared-pool 等既有分支一致，能直接表達功能序號與工作內容。

本輪檢查 PR #20 於 2026-06-21 02:28 UTC 的最新 Claude Bot 複審。重新核對專案憲章、005-request-attachments 規格、計畫與現行安全邊界後，未發現憲章或規格衝突，因此未進入提問模式。

## 累積調整

### PR #19 最新複審後續

- 新增共用 attachment-format utility，統一 Attendance、Subsidy 歷程與附件清單的 MiB 格式及結構化 audit 顯示。
- 無附件批次以 null 表達未建立 upload session，移除空字串 sentinel。
- 附件預覽 dialog 加入具 aria-label 的關閉按鈕。
- Attendance 與 Subsidy 儲存流程對非 Error rejection 提供固定繁中 fallback。
- 在 attendanceLogs 更新規則旁明記非附件欄位的 authenticated 開放屬既有歷史行為，全面權限收斂另案處理。

### PR #20 最新 Claude 複審

- 將 JSON audit payload 視為 unknown，逐筆驗證元素必須為物件，originalName 必須為字串，size 必須為有限數字。
- 損壞、缺欄位、null 或非有限數值項目會被略過，不再顯示 undefined（NaN MiB）。
- 新增 undefined content、空陣列與混合損壞／合法資料的邊界測試。
- AttachmentListComponent 改為直接公開共用格式化函式參照，移除無附加邏輯的 wrapper。
- 將 dialog title SCSS 展開為多行，改善維護與 code review 可讀性。

## 複審判定

- Storage create rule 已驗證 metadata.requestKind、requestId、attachmentId、uploadedBy，並透過 upload session 驗證 ownerUid；不需重複修改。
- request attachment 的兩份 xdescribe contract spec 已明記真正執行入口為 npm run test:attachment-rules。
- attendance 非附件更新權限是既有技術債，本 PR 只記錄而不夾帶全面權限重構，避免偏離 005 規格。
- Emulator runner 遷移測試框架屬非阻斷維護重構，現有可執行 Rules matrix 維持不變。

## 驗證

- npm test -- --watch=false：227 SUCCESS、68 skipped。
- app/spec TypeScript noEmit：通過。
- Firestore／Storage Emulator Rules matrix：PASS。
- attachment orphan audit：PASS。
- git diff --check：PASS。
- production build 仍受本機 node_modules 的 darwin-arm64 esbuild 與目前 darwin-x64 Node 架構不符阻擋；bundling 尚未開始，並非本次程式碼編譯錯誤。

## 變更與合併說明

- 本 PR 未包含工作目錄既有的 .gitignore、AGENTS.md 與 .codex/ 變更。
- PR #20 將在本 PR 建立後關閉，避免兩個 PR 指向相同提交內容。
- 合併時請依儲存庫偏好使用 merge commit，不使用 squash merge。