### PR TITLE
security: 收斂 attendance 非附件欄位更新權限 (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Subsidy 申請儲存失敗時保留 dialog 與使用者已選資料，改在表單內顯示錯誤，不再以「建立失敗」結果直接關閉 dialog。
 
 ### 安全
+- **Breaking security change**：收斂 `attendanceLogs` 的更新權限（GitHub issue #22）。原本任意已登入使用者皆可修改他人申請的非附件欄位（`status`、`reason`、`type` 等），現收斂為僅 admin 或「pending 狀態下的申請人本人」可更新，且 status 轉換（核准／拒絕／退回待審）一律保留給 admin。若有 kiosk 或外部整合曾以非 owner／非 admin 身分修改他人 attendance 欄位，部署前必須改用 admin 或申請人本人帳號。詳見 `specs/007-attendance-permission-hardening/`。
 - **Breaking security change**：`attendanceLogs` 的讀取、建立與更新由匿名可存取收斂為至少需要 Firebase Authentication 登入；若有 kiosk 或外部整合曾依賴匿名寫入，部署前必須改用已登入流程。
 - 新增 Firestore／Storage Rules 附件權限矩陣：登入者可預覽、owner 僅能修改自己的 pending 申請、admin 可代辦；未登入、Storage list、同路徑 overwrite、缺少 actor 的 cleanup queue 刪除授權及未搭配 parent removal 的 queue create 均拒絕。
 - Storage attachment path 採 create-only，正式 bucket CORS 僅允許 Firebase Hosting origins 與本機 `http://localhost:4200` 的 `GET`／`HEAD`。

--- a/firestore.rules
+++ b/firestore.rules
@@ -54,6 +54,15 @@ service cloud.firestore {
       return !('attachments' in data) || (data.attachments is list && data.attachments.size() <= 5);
     }
 
+    // 申請人僅能在自己仍為 pending 的 attendance 申請上編輯內容與附件，
+    // 且不得變更 userId 與 status；status 轉換（核准／拒絕／退回待審）一律收斂為 admin。
+    function attendanceOwnerEditable(existing, incoming, uid) {
+      return existing.userId == uid
+        && existing.status == 'pending'
+        && incoming.userId == existing.userId
+        && incoming.status == existing.status;
+    }
+
     function validAttendanceAuditAction(action) {
       return action in ['create', 'update', '建立', '更新', '新增附件', '刪除附件'];
     }
@@ -94,13 +103,12 @@ service cloud.firestore {
       allow create: if isSignedIn() && validAttachmentCount(request.resource.data)
         && (!('attachments' in request.resource.data) || request.resource.data.attachments.size() == 0
           || request.resource.data.userId == request.auth.uid || isAdmin());
-      // 已知歷史行為：非附件欄位仍允許任意已登入使用者更新；權限收斂追蹤：GitHub issue #22。
+      // 權限收斂（GitHub issue #22）：attendance 文件僅允許 admin 或「pending 狀態下的申請人本人」更新；
+      // 其他已登入使用者不得修改他人申請的任何欄位（含 status、reason、type 等非附件欄位）。
+      // status 轉換一律保留給 admin，避免申請人自我核准或非授權者越權審核。
       allow update: if isSignedIn() && validAttachmentCount(request.resource.data)
-        && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['attachments'])
-          || isAdmin()
-          || (resource.data.userId == request.auth.uid && resource.data.status == 'pending'
-            && request.resource.data.userId == resource.data.userId
-            && request.resource.data.status == resource.data.status));
+        && (isAdmin()
+          || attendanceOwnerEditable(resource.data, request.resource.data, request.auth.uid));
       allow delete: if isAdmin();
 
       match /auditTrail/{auditId} {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "ng test",
     "test:attachment-audit": "node --test tools/request-attachment-orphan-audit.test.js",
     "test:attachment-rules": "firebase emulators:exec --config firebase.local.json --project demo-request-attachments --only firestore,storage \"node tools/request-attachment-emulator-tests.cjs\"",
+    "test:attendance-rules": "firebase emulators:exec --config firebase.local.json --project demo-attendance-permission --only firestore \"node tools/attendance-permission-emulator-tests.cjs\"",
     "test:journey-rules": "firebase emulators:exec --config firebase.local.json --project demo-user-journey --only firestore,storage \"node tools/journey-event-emulator-tests.cjs\"",
     "audit:request-attachments": "node tools/request-attachment-orphan-audit.js",
     "audit:request-attachments:local": "node tools/request-attachment-orphan-audit.js --fixture src/app/attachments/testing/orphan-audit-fixture.json"

--- a/specs/007-attendance-permission-hardening/plan.md
+++ b/specs/007-attendance-permission-hardening/plan.md
@@ -1,0 +1,72 @@
+# 實作計畫：收斂 attendance 更新權限
+
+**功能分支**：`security/022-attendance-update-permission`
+**對應規格**：`specs/007-attendance-permission-hardening/spec.md`
+**來源**：GitHub issue #22
+
+> 憲章要求：本文件記錄技術實作、Firestore 結構、安全規則、相容性與測試策略；產品需求與驗收標準請見 spec.md。
+
+## 技術範圍
+
+僅調整 `firestore.rules` 中 `attendanceLogs` 的 `allow update` 邊界，並補上對應 Emulator 測試矩陣。不變更 Angular 服務、元件或資料模型；附件上傳 session／cleanup queue／storage.rules 維持現狀。
+
+## Security Rules 設計
+
+新增輔助函數，將「申請人僅能在 pending 編輯自己申請」的不變量集中表達：
+
+```
+function attendanceOwnerEditable(existing, incoming, uid) {
+  return existing.userId == uid
+    && existing.status == 'pending'
+    && incoming.userId == existing.userId
+    && incoming.status == existing.status;
+}
+```
+
+`attendanceLogs` 的 update 規則由原本的三段 OR：
+
+```
+!affectedKeys().hasAny(['attachments'])   // 任意登入者可改非附件欄位（風險來源）
+  || isAdmin()
+  || (owner && pending && userId/status 不變)
+```
+
+收斂為：
+
+```
+allow update: if isSignedIn() && validAttachmentCount(request.resource.data)
+  && (isAdmin()
+    || attendanceOwnerEditable(resource.data, request.resource.data, request.auth.uid));
+```
+
+關鍵差異：移除「`!affectedKeys().hasAny(['attachments'])` ⇒ 任意登入者可更新非附件欄位」分支。改為只有 admin 或 pending 狀態的 owner 可更新；status 轉換因 `incoming.status == existing.status` 限制而對 owner 關閉，僅 admin 可變更。
+
+### 為何 status 轉換歸 admin 是相容的
+
+`AttendanceService.updateStatus()`（核准／退回）對 `AnnualLeave` 會連帶寫入 `users/{userId}.remainingLeaveHours`。既有 `users` 規則僅允許 admin 或本人更新自己的非敏感欄位，因此「非 admin 替他人結算特休時數」在現行規則下早已失敗。將 attendance status 轉換收斂為 admin，與既有 users 規則一致，不擴大也不縮小實際可用的審核流程。
+
+## 受影響檔案
+
+- `firestore.rules`：新增 `attendanceOwnerEditable` 與改寫 attendance `allow update`。
+- `tools/attendance-permission-emulator-tests.cjs`：新增權限矩陣測試。
+- `package.json`：新增 `test:attendance-rules` script。
+- `CHANGELOG.md`：記為 breaking security change。
+
+## 相容性、資料遷移與部署順序
+
+- **資料遷移**：無。僅變更存取規則，不改文件結構或既有資料。
+- **kiosk／外部整合相容性**：attendance 讀寫已於先前版本收斂為需登入；本次再移除「任意登入者改非附件欄位」路徑。若有任何整合曾以非 owner／非 admin 身分修改他人申請欄位，部署後將被拒絕，必須改用 admin 帳號或申請人本人帳號。經檢視，現行 Angular 前端的編輯入口僅在 pending 顯示且實際寫入由 owner 或 admin 觸發，status 轉換流程亦依賴 users 規則的 admin 邊界，故前端不受影響。
+- **部署順序**：Security Rules 可獨立於前端先行部署；無需資料前置遷移。建議先於 staging 以 Emulator 矩陣與手動審核流程驗證，再部署 production rules。
+
+## 測試策略
+
+- 以 `@firebase/rules-unit-testing` 建立 Emulator 正向／負向矩陣，至少涵蓋 owner（pending 可編輯內容／附件、不可自我核准、不可改 userId）、owner（非 pending 不可編輯）、admin（任意狀態可編輯與轉換 status）、other-user（任何欄位皆拒絕）、anonymous（拒絕）與 status transition。
+- 既有 `tools/request-attachment-emulator-tests.cjs` 中「owner 於 pending 更新非附件欄位成功」的回歸案例必須維持通過。
+- 執行方式：
+  - `npm run test:attendance-rules`
+  - `npm run test:attachment-rules`（回歸）
+
+## 風險與緩解
+
+- **風險**：若 production 曾存在非 owner／非 admin 的合法寫入路徑（未知整合），部署後會中斷。
+  - **緩解**：CHANGELOG 標示為 breaking security change，部署前需確認無此類整合；必要時改以 admin 帳號操作。

--- a/specs/007-attendance-permission-hardening/spec.md
+++ b/specs/007-attendance-permission-hardening/spec.md
@@ -1,0 +1,79 @@
+# 功能規格：收斂 attendance 更新權限
+
+**功能分支**：`security/022-attendance-update-permission`
+**建立日期**：2026-06-26
+**狀態**：草稿
+**輸入**：GitHub issue #22「security: 收斂 attendance 非附件欄位更新權限」
+
+> 憲章要求：本文件 MUST 以繁體中文（zh-TW）撰寫，且僅記錄產品需求、使用者價值、驗收條件與成功標準。技術實作、Firestore 結構、安全規則與套件決策請寫入 plan.md。
+
+## 文件範圍確認 *(mandatory)*
+
+- 本文件聚焦「各角色對 attendance 申請可以做什麼」與「如何驗收權限邊界」，不含 Security Rules 語法。
+- 範圍限定 `attendanceLogs` 文件的更新權限；不變更 subsidy 申請或既有讀取／建立／刪除語意。
+- 名詞、錯誤訊息與使用者可見說明使用繁體中文。
+
+## 背景與問題 *(mandatory)*
+
+attendance 申請導入附件功能前，採用歷史權限模型：只要是已登入使用者，即使不是申請人本人或管理員，仍可透過 Firestore SDK 直接修改他人申請的非附件欄位（如 `status`、`reason`、`type`）。UI 雖未提供入口，但 UI 限制不能取代資料邊界，形成越權修改風險。依專案憲章 Governance，不得將既有偏差視為默認標準，必須以明確規格收斂。
+
+## 角色定義 *(mandatory)*
+
+- **申請人（owner）**：`attendanceLogs.userId` 等於目前登入者。
+- **管理員（admin）**：`users/{uid}.role == 'admin'`，負責審核與代辦。
+- **其他登入者（other）**：已登入但非該申請的 owner，也非 admin。
+- **未登入者（anonymous）**：未通過 Firebase Authentication。
+
+> 本專案目前未設獨立「審核者」角色；審核（status 轉換）權限歸屬 admin。若日後新增審核者角色，需另立規格擴充。
+
+## 權限矩陣 *(mandatory)*
+
+| 操作 | 申請人（pending） | 申請人（非 pending） | 管理員 | 其他登入者 | 未登入者 |
+| --- | --- | --- | --- | --- | --- |
+| 編輯內容欄位（reason/type/時間/時數等） | 允許 | 拒絕 | 允許 | 拒絕 | 拒絕 |
+| 管理自己的附件 | 允許 | 拒絕 | 允許 | 拒絕 | 拒絕 |
+| status 轉換（核准／拒絕／退回待審） | 拒絕 | 拒絕 | 允許 | 拒絕 | 拒絕 |
+| 變更 `userId`（轉移申請） | 拒絕 | 拒絕 | 允許 | 拒絕 | 拒絕 |
+
+- 申請人只能在自己的申請仍為 `pending` 時編輯內容與附件，且不得在編輯動作中變更 `userId` 或 `status`。
+- 所有 status 轉換（含 `pending → approved`、`pending → rejected`、`approved/rejected → pending`）一律由 admin 執行，避免申請人自我核准或其他登入者越權審核。
+- 讀取（任何登入者可讀）、建立（依既有附件規則）、刪除（admin）權限維持不變。
+
+## 使用者情境與測試 *(mandatory)*
+
+### 使用者故事 1 - 申請人維護自己的待審申請 (Priority: P1)
+
+申請人在自己的申請仍為待審（pending）時，可修改內容與附件以補正資料。
+
+**驗收情境**：
+1. **Given** 申請人有一筆 pending 申請，**When** 修改 reason 並儲存，**Then** 更新成功。
+2. **Given** 申請已核准（approved），**When** 申請人嘗試修改內容或附件，**Then** 被拒絕，需由管理員代辦。
+3. **Given** 申請人有一筆 pending 申請，**When** 嘗試把 status 改為 approved（自我核准），**Then** 被拒絕。
+
+### 使用者故事 2 - 管理員審核與代辦 (Priority: P1)
+
+管理員可在任何狀態下審核、編輯與退回申請。
+
+**驗收情境**：
+1. **Given** 一筆 pending 申請，**When** 管理員核准，**Then** status 轉為 approved 並完成既有特休時數結算流程。
+2. **Given** 任一狀態的申請，**When** 管理員編輯非附件欄位或退回待審，**Then** 更新成功。
+
+### 使用者故事 3 - 阻擋越權修改 (Priority: P1)
+
+其他登入者與未登入者不得修改不屬於自己的申請。
+
+**驗收情境**：
+1. **Given** 申請屬於他人，**When** 其他登入者嘗試修改 reason、type、status 或附件，**Then** 全部被拒絕。
+2. **Given** 任一申請，**When** 未登入者嘗試更新，**Then** 被拒絕。
+
+## 驗收標準 *(mandatory)*
+
+- 任意已登入使用者不可修改不屬於自己的 attendance 文件，除非其角色（admin）在本規格中明確獲授權。
+- 所有允許的 status transition 與可修改欄位均由 Firestore Security Rules 驗證，並有 Emulator 正向／負向矩陣覆蓋。
+- 申請人於 pending 編輯自己申請的既有合法流程不得回歸。
+- 不改變既有讀取、建立、刪除與附件治理語意。
+
+## 來源
+
+- GitHub issue #22
+- 關聯：PR #19、PR #21、specs/005-request-attachments/plan.md。

--- a/tools/attendance-permission-emulator-tests.cjs
+++ b/tools/attendance-permission-emulator-tests.cjs
@@ -1,0 +1,81 @@
+const { initializeTestEnvironment, assertFails, assertSucceeds } = require('@firebase/rules-unit-testing');
+const { doc, setDoc, updateDoc } = require('firebase/firestore');
+
+// GitHub issue #22：收斂 attendanceLogs 非附件欄位的更新權限。
+// 驗證矩陣涵蓋 owner、other-user、admin、未登入者，以及 status transition。
+const projectId = 'demo-attendance-permission';
+const ownerUid = 'attendance-owner';
+const otherUid = 'attendance-other';
+const adminUid = 'attendance-admin';
+
+async function main() {
+  const env = await initializeTestEnvironment({ projectId });
+  try {
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await Promise.all([
+        setDoc(doc(db, 'users', ownerUid), { role: 'user' }),
+        setDoc(doc(db, 'users', otherUid), { role: 'user' }),
+        setDoc(doc(db, 'users', adminUid), { role: 'admin' }),
+      ]);
+    });
+
+    const owner = env.authenticatedContext(ownerUid);
+    const other = env.authenticatedContext(otherUid);
+    const admin = env.authenticatedContext(adminUid);
+    const anonymous = env.unauthenticatedContext();
+    const ownerDb = owner.firestore();
+
+    const attachment = {
+      id: 'a1', storagePath: 'request-attachments/attendance/pending/session/a1',
+      originalName: 'proof.pdf', contentType: 'application/pdf', size: 5,
+      uploadedBy: ownerUid, uploadedAt: new Date(),
+    };
+
+    // 申請人於 pending 建立自己的 attendance 申請。
+    await assertSucceeds(setDoc(doc(ownerDb, 'attendanceLogs', 'pending'), {
+      userId: ownerUid, status: 'pending', type: 1, reason: 'origin', hours: 8, attachments: [],
+    }));
+
+    // 1. 申請人本人可在 pending 編輯非附件欄位（既有合法流程不得回歸）。
+    await assertSucceeds(updateDoc(doc(ownerDb, 'attendanceLogs', 'pending'), { reason: 'owner edit' }));
+    // 2. 申請人本人可在 pending 管理自己的附件。
+    await assertSucceeds(updateDoc(doc(ownerDb, 'attendanceLogs', 'pending'), { attachments: [attachment] }));
+    // 3. 申請人不得自我核准（status 轉換保留給 admin）。
+    await assertFails(updateDoc(doc(ownerDb, 'attendanceLogs', 'pending'), { status: 'approved' }));
+    // 4. 申請人不得竄改 userId 將申請轉移。
+    await assertFails(updateDoc(doc(ownerDb, 'attendanceLogs', 'pending'), { userId: otherUid }));
+
+    // 5. 其他登入者不得修改他人的非附件欄位（issue #22 核心修正）。
+    await assertFails(updateDoc(doc(other.firestore(), 'attendanceLogs', 'pending'), { reason: 'hijack' }));
+    await assertFails(updateDoc(doc(other.firestore(), 'attendanceLogs', 'pending'), { status: 'approved' }));
+    await assertFails(updateDoc(doc(other.firestore(), 'attendanceLogs', 'pending'), { type: 3 }));
+    // 6. 其他登入者亦不得修改他人附件。
+    await assertFails(updateDoc(doc(other.firestore(), 'attendanceLogs', 'pending'), { attachments: [] }));
+
+    // 7. 未登入者一律拒絕更新。
+    await assertFails(updateDoc(doc(anonymous.firestore(), 'attendanceLogs', 'pending'), { reason: 'anon' }));
+
+    // 8. admin 可核准（pending -> approved）。
+    await assertSucceeds(updateDoc(doc(admin.firestore(), 'attendanceLogs', 'pending'), { status: 'approved' }));
+
+    // 9. 申請已核准後，申請人不得再編輯非附件欄位或附件（僅 admin 可代辦）。
+    await assertFails(updateDoc(doc(ownerDb, 'attendanceLogs', 'pending'), { reason: 'late edit' }));
+    await assertFails(updateDoc(doc(ownerDb, 'attendanceLogs', 'pending'), { attachments: [] }));
+    // 10. admin 可在任何狀態下編輯非附件欄位與退回待審。
+    await assertSucceeds(updateDoc(doc(admin.firestore(), 'attendanceLogs', 'pending'), { reason: 'admin amend' }));
+    await assertSucceeds(updateDoc(doc(admin.firestore(), 'attendanceLogs', 'pending'), { status: 'pending' }));
+
+    // 11. 其他登入者不得將他人申請退回待審。
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await updateDoc(doc(ctx.firestore(), 'attendanceLogs', 'pending'), { status: 'rejected' });
+    });
+    await assertFails(updateDoc(doc(other.firestore(), 'attendanceLogs', 'pending'), { status: 'pending' }));
+
+    console.log('Attendance permission emulator matrix: PASS');
+  } finally {
+    await env.cleanup();
+  }
+}
+
+main().catch((error) => { console.error(error); process.exitCode = 1; });


### PR DESCRIPTION
## 背景

Closes #22。

導入附件功能前的歷史權限模型下，`attendanceLogs` 的 `update` 規則中存在
`!affectedKeys().hasAny(['attachments'])` 分支，使**任意已登入使用者**都能透過
Firestore SDK 直接修改他人申請的非附件欄位（`status`、`reason`、`type` 等），形成越權修改風險。
依專案憲章 Governance，不得將既有偏差視為默認標準，故以獨立 spec 收斂。

## 變更內容

- **`firestore.rules`**
  - 移除「任意登入者可改非附件欄位」分支。
  - attendance `update` 收斂為：僅 `admin` 或 **pending 狀態下的申請人本人**可更新。
  - status 轉換（核准／拒絕／退回待審）一律保留給 `admin`，避免申請人自我核准或其他登入者越權審核。
  - 新增 `attendanceOwnerEditable()` 輔助函數，集中表達「pending owner 不可變更 `userId`/`status`」不變量。
- **`tools/attendance-permission-emulator-tests.cjs` + `npm run test:attendance-rules`**
  - 正向／負向矩陣，涵蓋 owner（pending 可編輯、非 pending 不可、不可自我核准、不可改 userId）、admin（任意狀態可編輯與轉換 status）、other-user（任何欄位皆拒絕）、anonymous（拒絕）與 status transition。
- **`specs/007-attendance-permission-hardening/`**
  - `spec.md`：角色定義與權限矩陣（產品需求）。
  - `plan.md`：Rules 設計、相容性、資料遷移與部署順序（技術實作）。
- **`CHANGELOG.md`**：標示為 breaking security change。

## 相容性

- 無資料遷移；僅變更存取規則。
- `updateStatus()` 對特休的 `users.remainingLeaveHours` 結算在現行 `users` 規則下早已需要 admin，故 status 轉換收斂為 admin 與既有邊界一致，不影響合法審核流程。
- 前端編輯入口僅在 pending 顯示且實際寫入由 owner 或 admin 觸發，不受影響。
- 若有外部整合曾以非 owner／非 admin 身分修改他人 attendance 欄位，部署後會被拒絕，需改用 admin 或申請人本人帳號。

## 驗證

- `npm run test:attendance-rules` → PASS
- `npm run test:attachment-rules`（回歸，含 owner pending 編輯非附件欄位成功案例）→ PASS

## 驗收標準對應

- [x] 任意已登入使用者不可修改不屬於自己的 attendance 文件，admin 例外。
- [x] 所有允許的 status transition 與可修改欄位均由 Rules 驗證並有 Emulator 矩陣覆蓋。
- [x] 既有 owner pending 編輯流程不回歸。
- [x] 不改變既有讀取／建立／刪除與附件治理語意。

🤖 Generated with [Claude Code](https://claude.com/claude-code)